### PR TITLE
Add gating tests of K8s integration

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -14,5 +14,6 @@ flake8>=2.2.4,<=2.4.1
 stestr>=2.2.0
 coverage>=4.5.2
 pyudev              # for ceph-* charm unit tests (need to fix the ceph-* charm unit tests/mocking)
-git+https://github.com/openstack-charmers/zaza.git#egg=zaza;python_version>='3.0'
-git+https://github.com/openstack-charmers/zaza-openstack-tests.git#egg=zaza.openstack
+#git+https://github.com/openstack-charmers/zaza.git#egg=zaza;python_version>='3.0'
+#git+https://github.com/openstack-charmers/zaza-openstack-tests.git#egg=zaza.openstack
+git+https://github.com/johnsca/zaza-openstack-tests@ceph-k8s-tests#egg=zaza.openstack

--- a/tests/bundles/bionic-train-k8s.yaml
+++ b/tests/bundles/bionic-train-k8s.yaml
@@ -1,0 +1,71 @@
+series: bionic
+applications:
+  ceph-osd:
+    charm: ceph-osd
+    num_units: 3
+    series: bionic
+    storage:
+      osd-devices: '10G'
+    options:
+      osd-devices: '/dev/test-non-existent'
+      source: cloud:bionic-train
+  ceph-mon:
+    charm: cs:~openstack-charmers-next/ceph-mon
+    num_units: 3
+    options:
+      monitor-count: '3'
+      source: cloud:bionic-train
+  kubernetes-master:
+    charm: cs:~containers/kubernetes-master
+    constraints: cores=2 mem=4G root-disk=16G
+    expose: true
+    num_units: 1
+  kubernetes-worker:
+    charm: cs:~containers/kubernetes-worker
+    constraints: cores=4 mem=4G root-disk=16G
+    num_units: 1
+  containerd:
+    charm: cs:~containers/containerd
+  flannel:
+    charm: cs:~containers/flannel
+  easyrsa:
+    charm: cs:~containers/easyrsa
+    num_units: 1
+    to:
+    - lxd:kubernetes-master/0
+  etcd:
+    charm: cs:~containers/etcd
+    num_units: 1
+    options:
+      channel: 3.3/stable
+    to:
+    - kubernetes-master/0
+relations:
+- - ceph-osd:mon
+  - ceph-mon:osd
+- - ceph-mon:admin
+  - kubernetes-master
+- - ceph-mon:client
+  - kubernetes-master
+- - kubernetes-master:kube-api-endpoint
+  - kubernetes-worker:kube-api-endpoint
+- - kubernetes-master:kube-control
+  - kubernetes-worker:kube-control
+- - kubernetes-master:certificates
+  - easyrsa:client
+- - kubernetes-master:etcd
+  - etcd:db
+- - kubernetes-worker:certificates
+  - easyrsa:client
+- - etcd:certificates
+  - easyrsa:client
+- - flannel:etcd
+  - etcd:db
+- - flannel:cni
+  - kubernetes-master:cni
+- - flannel:cni
+  - kubernetes-worker:cni
+- - containerd:containerd
+  - kubernetes-worker:container-runtime
+- - containerd:containerd
+  - kubernetes-master:container-runtime

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -10,13 +10,36 @@ gate_bundles:
   - xenial-ocata
   - xenial-mitaka
   - trusty-mitaka
+  - k8s: bionic-train-k8s
 smoke_bundles:
   - bionic-train
 dev_bundles:
 configure:
   - zaza.openstack.charm_tests.glance.setup.add_lts_image
+  - k8s: []
 tests:
   - zaza.openstack.charm_tests.ceph.tests.CephLowLevelTest
   - zaza.openstack.charm_tests.ceph.tests.CephRelationTest
   - zaza.openstack.charm_tests.ceph.tests.CephTest
   - zaza.openstack.charm_tests.ceph.osd.tests.SecurityTest
+  - k8s:
+    - zaza.openstack.charm_tests.ceph.tests.CephK8sTest
+target_deploy_status:
+  easyrsa:
+    workload-status: active
+    workload-status-message: "Certificate Authority connected."
+  etcd:
+    workload-status: active
+    workload-status-message: "Healthy"
+  kubernetes-master:
+    workload-status: active
+    workload-status-message: "Kubernetes master running."
+  kubernetes-worker:
+    workload-status: active
+    workload-status-message: "Kubernetes worker running."
+  containerd:
+    workload-status: active
+    workload-status-message: "Container runtime available"
+  flannel:
+    workload-status: active
+    workload-status-message: "Flannel subnet"


### PR DESCRIPTION
This is a draft PR just for linking and discussion purposes.  When this is actually ready, this PR should be closed and a proper Gerrit review created.

I haven't been able to get this to work, since the `k8s` bundle alias insists on picking up the configure step for the unnamed bundle but since Glance isn't included, it fails.  (Same issue in johnsca/charm-ceph-fs#1)

This depends on the new tests in openstack-charmers/zaza-openstack-tests#205